### PR TITLE
Adds configurable host and port settings for development

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -7,7 +7,8 @@ use Mix.Config
 # watchers to your application. For example, we use it
 # with brunch.io to recompile .js and .css sources.
 config :faros, Faros.Endpoint,
-  http: [port: 4000],
+  http: [host: System.get_env("HOST") || "localhost",
+         port: System.get_env("PORT") || "4000"],
   debug_errors: true,
   code_reloader: true,
   cache_static_lookup: false,


### PR DESCRIPTION
This allows the port and host to be externally configurable.
It's mostly because the default settings do not work when running Phoenix in a VM for local development.

I'm not sure about how the other environments are meant to be configured, so I just added this to `dev.exs` for now.