### PR TITLE
Add some basic form validations for papers.

### DIFF
--- a/lib/faros/papers/paper.ex
+++ b/lib/faros/papers/paper.ex
@@ -14,6 +14,7 @@ defmodule Faros.Papers.Paper do
   def changeset(model, params \\ :empty) do
     model
     |> cast(params, @required_fields)
+    |> validate_format(:link, ~r/http:\/\//)
     |> unique_constraint(:slug)
   end
 end

--- a/test/papers/controller_test.exs
+++ b/test/papers/controller_test.exs
@@ -29,7 +29,7 @@ defmodule Faros.Papers.ControllerTest do
       "author"      => "b",
       "slug"        => "abc",
       "description" => "d",
-      "link"        => "e"
+      "link"        => "http://test"
     }
     conn = post conn(), "/papers", %{"paper" => params}
     assert html_response(conn, 302)
@@ -46,7 +46,7 @@ defmodule Faros.Papers.ControllerTest do
       "author" => "b",
       "slug" => "abc",
       "description" => "d",
-      "link" => "e"
+      "link" => "http://blah"
     }
 
     post conn(), "/papers", %{"paper" => params, "category": category.name}

--- a/test/papers/query_test.exs
+++ b/test/papers/query_test.exs
@@ -10,6 +10,11 @@ defmodule Faros.Papers.QueryTest do
     assert Query.all() |> Enum.count == 2
   end
 
+  test "link must be a valid url" do
+    {:error, changeset} = %{sample_paper() | link: "not-a-link"} |> Query.save
+    assert changeset.errors[:link]
+  end
+
   test "slug has to be unique" do
     {:ok, _ } = sample_paper("the-first") |> Query.save
     {:error, changeset} = sample_paper("the-first") |> Query.save

--- a/test/support/sample_data.ex
+++ b/test/support/sample_data.ex
@@ -17,7 +17,7 @@ defmodule Faros.SampleData do
       author: "Mister Doctor Esquire",
       slug:  Slugger.generate(title),
       description: "My research from 1845",
-      link: "www.fancy-paper-r-us.com/fancy-paper"
+      link: "http://www.fancy-paper-r-us.com/fancy-paper"
     }
   end
 end


### PR DESCRIPTION
Took a quick look at: https://github.com/felipesere/faros/issues/51.

Felt kind of arbitrary adding length requirements for fields that we already require not to be blank. So I added a link formatting requirement. Might be better to accept anything and if it doesn't begin with `http` or `https` then we prepend that instead.

Thoughts?