### PR TITLE
Assert refute validations

### DIFF
--- a/lib/faros/books/book.ex
+++ b/lib/faros/books/book.ex
@@ -16,6 +16,7 @@ defmodule Faros.Books.Book do
     |> cast(params, @required_fields)
     |> normalize
     |> validate_format(:isbn, ~r/[\d]{13}/)
+    |> validate_length(:isbn, is: 13)
     |> validate_length(:title, min: 3)
     |> validate_format(:link, ~r/http:\/\//)
     |> validate_length(:slug, min: 5)

--- a/test/books/query_test.exs
+++ b/test/books/query_test.exs
@@ -2,6 +2,7 @@ defmodule Faros.Books.QueryTest do
   use Faros.RepositoryCase
   import Faros.SampleData, only: [sample_book: 0, sample_book: 1]
   alias Faros.Books.Query
+  alias Faros.Books.Book
 
   test "save a book to the database" do
     {:ok, book} = sample_book() |> Query.save
@@ -10,33 +11,33 @@ defmodule Faros.Books.QueryTest do
   end
 
   test "can not save book with title less than three characters" do
-    {:error, changeset} = %{sample_book() | title: ""} |> Query.save
-    assert changeset.errors[:title]
+    changeset = Book.changeset(%Book{}, %{sample_book() | title: ""})
+    refute changeset.valid?
   end
 
   test "will not save book with an invalid URL" do
-    {:error, changeset} = %{sample_book() | link: "not-really-a-url"} |> Query.save
-    assert changeset.errors[:link]
+    changeset = Book.changeset(%Book{}, %{sample_book() | link: "not-really-a-url"})
+    refute changeset.valid?
   end
 
   test "will normalize ISBN before saving" do
-    {:ok, book} = %{sample_book() | isbn: "1234-5678-9012-3"} |> Query.save
-    assert "1234567890123" == book.isbn
+    changeset = Book.changeset(%Book{}, %{sample_book() | isbn: "1234-5678-9012-3"})
+    assert "1234567890123" == changeset.changes.isbn
   end
 
   test "will not save a book with a short isbn" do
-    {:error, changeset} = %{sample_book() | isbn: "123"} |> Query.save
-    assert changeset.errors[:isbn]
+    changeset = Book.changeset(%Book{}, %{sample_book() | isbn: "123"})
+    refute changeset.valid?
   end
 
   test "isbn may only contain numeric values" do
-    {:error, changeset} = %{sample_book() | isbn: "123-456-789-abcd"} |> Query.save
-    assert changeset.errors[:isbn]
+    changeset = Book.changeset(%Book{}, %{sample_book() | isbn: "123-456-789-abcd"})
+    refute changeset.valid?
   end
 
   test "will not save if slug is not present" do
-    {:error, changeset} = %{sample_book() | slug: ""} |> Query.save
-    assert changeset.errors[:slug]
+    changeset = Book.changeset(%Book{}, %{sample_book() | slug: ""})
+    refute changeset.valid?
   end
 
   test "slugs of books must be unique" do

--- a/test/books/query_test.exs
+++ b/test/books/query_test.exs
@@ -10,36 +10,6 @@ defmodule Faros.Books.QueryTest do
     assert sample_book().slug == book.slug
   end
 
-  test "can not save book with title less than three characters" do
-    changeset = Book.changeset(%Book{}, %{sample_book() | title: ""})
-    refute changeset.valid?
-  end
-
-  test "will not save book with an invalid URL" do
-    changeset = Book.changeset(%Book{}, %{sample_book() | link: "not-really-a-url"})
-    refute changeset.valid?
-  end
-
-  test "will normalize ISBN before saving" do
-    changeset = Book.changeset(%Book{}, %{sample_book() | isbn: "1234-5678-9012-3"})
-    assert "1234567890123" == changeset.changes.isbn
-  end
-
-  test "will not save a book with a short isbn" do
-    changeset = Book.changeset(%Book{}, %{sample_book() | isbn: "123"})
-    refute changeset.valid?
-  end
-
-  test "isbn may only contain numeric values" do
-    changeset = Book.changeset(%Book{}, %{sample_book() | isbn: "123-456-789-abcd"})
-    refute changeset.valid?
-  end
-
-  test "will not save if slug is not present" do
-    changeset = Book.changeset(%Book{}, %{sample_book() | slug: ""})
-    refute changeset.valid?
-  end
-
   test "slugs of books must be unique" do
     {:ok, _} = sample_book() |> Query.save
     {:error, changeset} = sample_book() |> Query.save

--- a/test/books/validation_test.exs
+++ b/test/books/validation_test.exs
@@ -19,11 +19,11 @@ defmodule Faros.Books.ValidationTest do
   end
 
   test "an ISBN must have 13 characters to be valid" do
-    changeset = Book.changeset(%Book{}, %{sample_book() | isbn: "123"})
-    refute changeset.valid?
+    short = Book.changeset(%Book{}, %{sample_book() | isbn: "123"})
+    refute short.valid?
 
-    changeset = Book.changeset(%Book{}, %{sample_book() | isbn: "123456789123456789"})
-    refute changeset.valid?
+    long = Book.changeset(%Book{}, %{sample_book() | isbn: "12345-67890-12345"})
+    refute long.valid?
   end
 
   test "ISBN can only contain numeric values" do

--- a/test/books/validation_test.exs
+++ b/test/books/validation_test.exs
@@ -1,0 +1,38 @@
+defmodule Faros.Books.ValidationTest do
+  use ExUnit.Case
+  alias Faros.Books.Book
+  import Faros.SampleData, only: [sample_book: 0]
+
+  test "a book with a blank title is invalid" do
+    changeset = Book.changeset(%Book{}, %{sample_book() | title: ""})
+    refute changeset.valid?
+  end
+
+  test "a book with an ill-formated url is invalid" do
+    changeset = Book.changeset(%Book{}, %{sample_book() | link: "not-really-a-url"})
+    refute changeset.valid?
+  end
+
+  test "ISBNs are normalized before saving" do
+    changeset = Book.changeset(%Book{}, %{sample_book() | isbn: "1234-5678-9012-3"})
+    assert "1234567890123" == changeset.changes.isbn
+  end
+
+  test "an ISBN must have 13 characters to be valid" do
+    changeset = Book.changeset(%Book{}, %{sample_book() | isbn: "123"})
+    refute changeset.valid?
+
+    changeset = Book.changeset(%Book{}, %{sample_book() | isbn: "123456789123456789"})
+    refute changeset.valid?
+  end
+
+  test "ISBN can only contain numeric values" do
+    changeset = Book.changeset(%Book{}, %{sample_book() | isbn: "123-456-789-abcd"})
+    refute changeset.valid?
+  end
+
+  test "a book with a blank slug is invalid" do
+    changeset = Book.changeset(%Book{}, %{sample_book() | slug: ""})
+    refute changeset.valid?
+  end
+end


### PR DESCRIPTION
This PR is a little experiment to figure out if `refute` reads better than `assert ! something`.

I also went ahead and checked the validation without having to actually save them by simply calling `.valid?` on them.